### PR TITLE
Update module go-simpler.org/env to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/rs/xid v1.5.0
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.4
-	go-simpler.org/env v0.9.0
+	go-simpler.org/env v0.10.0
 	golang.org/x/oauth2 v0.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go-simpler.org/env v0.9.0 h1:W3T9bcZdQVAMguhizy7Ne2cNojMxH4tguZZwZW02TQA=
 go-simpler.org/env v0.9.0/go.mod h1:zD5pZjlnLGGsm3SZirdcmlt+qADkhrXnumi/Z3YNyLE=
+go-simpler.org/env v0.10.0 h1:f1p5Y225GQyq1NDb9YLFdNTbZofZWfh/UfKMDQE1/8I=
+go-simpler.org/env v0.10.0/go.mod h1:cc/5Md9JCUM7LVLtN0HYjPTDcI3Q8TDaPlNTAlDU+WI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	ctx := context.Background()
 
 	var cfg Config
-	err := env.Load(&cfg)
+	err := env.Load(&cfg, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Hi!

GitHub tells me that your project uses one of my libraries, where I recently broke the public API a bit (sorry about that 😅).

So I decided to update it manually and send you a PR. The API is mostly stabilized, in fact, I'm thinking about releasing `v1` soon.

Again, sorry for the inconvenience.